### PR TITLE
Handle situations where the creator of the pull request wasn't found.

### DIFF
--- a/src/CollabAssist.Services/BuildService.cs
+++ b/src/CollabAssist.Services/BuildService.cs
@@ -27,7 +27,7 @@ namespace CollabAssist.Services
                 if (build.PullRequest != null)
                 {
                     var identifier = await _inputHandler.GetIdentifier(build.PullRequest, IdentifierKeys.Identifier);
-                    await _outputHandler.NotifyFailedPullRequestBuild(build, identifier).ConfigureAwait(false);
+                    return await _outputHandler.NotifyFailedPullRequestBuild(build, identifier).ConfigureAwait(false);
                 }
 
                 return false;


### PR DESCRIPTION
This deals with Azure DevOps system accounts for example that don't exist in Slack