### PR TITLE
Use the web URL of the build instead of the URL to the JSON of the build

### DIFF
--- a/src/CollabAssist.Incoming.DevOps/Models/DevOpsBuildNotification.cs
+++ b/src/CollabAssist.Incoming.DevOps/Models/DevOpsBuildNotification.cs
@@ -31,7 +31,8 @@ namespace CollabAssist.Incoming.DevOps.Models
             {
                 Id = Resource.Id.ToString(),
                 Project = ResourceContainers.Project.Id,
-                Url = Resource.Url
+                Url = Resource.Url,
+                WebUrl = Resource.Url.Replace("/_apis/build/Builds/", "/_build/results?buildId=")
             };
 
             switch (Resource.Status)

--- a/src/CollabAssist.Incoming/Models/Build.cs
+++ b/src/CollabAssist.Incoming/Models/Build.cs
@@ -8,6 +8,7 @@ namespace CollabAssist.Incoming.Models
         public string Project { get; set; }
         public string Name { get; set; }
         public string Url { get; set; }
+        public string WebUrl { get; set; }
         public BuildStatus Status { get; set; }
         public DateTime CreatedDate { get; set; }
         public string OwnerName { get; set; }

--- a/src/CollabAssist.Output.Slack/SlackMessageFormatter.cs
+++ b/src/CollabAssist.Output.Slack/SlackMessageFormatter.cs
@@ -95,7 +95,7 @@ namespace CollabAssist.Output.Slack
                 .HasPreviewText($"Build of your PR failed.");
 
             var buildString = !string.IsNullOrEmpty(build.Url)
-                ? $"<{build.Url}|the build>"
+                ? $"<{build.WebUrl}|the build>"
                 : "the build";
 
             if (pullRequestOwner != null)


### PR DESCRIPTION
The link in the message will now direct you to the web UI instead of showing you the JSON representation of the build